### PR TITLE
implement error trait for pvrecorder

### DIFF
--- a/sdk/rust/src/pvrecorder.rs
+++ b/sdk/rust/src/pvrecorder.rs
@@ -89,6 +89,8 @@ impl std::fmt::Display for RecorderError {
     }
 }
 
+impl std::error::Error for RecorderError {}
+
 const DEFAULT_DEVICE_INDEX: i32 = -1;
 const DEFAULT_FRAME_LENGTH: i32 = 512;
 const DEFAULT_MILLISECONDS: i32 = 1000;


### PR DESCRIPTION
This allows it to be used in a more general way, along with the `?` operator e.g.

```rust
fn main() -> Result<(), Box<dyn Error>> { todo!() }
```