### PR TITLE
Fix misleading classname typo in README

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -30,9 +30,9 @@ pip3 install pvrecorder
 Getting the list of input devices does not require an instance:
 
 ```python
-from pvrecorder import PVRecorder
+from pvrecorder import PvRecorder
 
-devices = PVRecorder.get_audio_devices()
+devices = PvRecorder.get_audio_devices()
 ```
 
 To start recording initialize the instance and run start:


### PR DESCRIPTION
Fixes an extremely minor typo that can confuse first time runners.