### PR TITLE
Fix typo in Node demo URL

### DIFF
--- a/binding/nodejs/README.md
+++ b/binding/nodejs/README.md
@@ -64,4 +64,4 @@ recorder.release();
 
 ## Demos
 
-[@picovoice/pvrecorder-demo](https://www.npmjs.com/package/@picovoice/pvrecorder-demo) provides command-line utilities for recording audio to a file.
+[@picovoice/pvrecorder-demo](https://www.npmjs.com/package/@picovoice/pvrecorder-node-demo) provides command-line utilities for recording audio to a file.

--- a/binding/nodejs/README.md
+++ b/binding/nodejs/README.md
@@ -64,4 +64,4 @@ recorder.release();
 
 ## Demos
 
-[@picovoice/pvrecorder-demo](https://www.npmjs.com/package/@picovoice/pvrecorder-node-demo) provides command-line utilities for recording audio to a file.
+[@picovoice/pvrecorder-node-demo](https://www.npmjs.com/package/@picovoice/pvrecorder-node-demo) provides command-line utilities for recording audio to a file.


### PR DESCRIPTION
I noticed a typo in the URL pointing to the Node demo package, thought I'd submit a quick PR to fix it.

Thanks!