### PR TITLE
Add types declaration path to allow type discovery

### DIFF
--- a/binding/nodejs/package.json
+++ b/binding/nodejs/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.4",
   "description": "Audio recorder sdk for Nodejs.",
   "main": "dist/index.js",
+  "types": "dist/types",
   "keywords": [
     "audio, audio recorder"
   ],


### PR DESCRIPTION
Currently, due to the missing `types` property in the `package.json`, this module causes an error in TypeScript since it cannot find the types, as shown in the screenshot below:

![image](https://github.com/user-attachments/assets/f8a143f2-32c9-4479-80ea-7a33adf4da47)

This issue is easily resolved by adding the relative path to the module typings to the `package.json` via the `types` property.