### PR TITLE
Set CMake policy version to 3.10

### DIFF
--- a/project/CMakeLists.txt
+++ b/project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 project(pv_recorder VERSION 1.2.0 DESCRIPTION "Picovoice audio recorder library.")
 
 set(CMAKE_C_STANDARD 99)

--- a/project/CMakeLists.txt
+++ b/project/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.4)
+cmake_policy(VERSION 3.10)
+
 project(pv_recorder VERSION 1.2.0 DESCRIPTION "Picovoice audio recorder library.")
 
 set(CMAKE_C_STANDARD 99)

--- a/project/CMakeLists.txt
+++ b/project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(pv_recorder VERSION 1.2.0 DESCRIPTION "Picovoice audio recorder library.")
 
 set(CMAKE_C_STANDARD 99)


### PR DESCRIPTION
CMake officially removed support for versions `< 3.5`, which means the latest and newer versions of CMake will refuse to build this project as is.

To resolve this I've set the `policy_version` to `3.10`, which signals to CMake that we've essentially tested this and agree with the behaviour for CMake version `3.10`. This does not limit newer versions from building the project, it just signals to them to act (CMake policy wise) as if they were version `3.10`. Likewise, versions `3.5` -> `3.10` will just act as they are.

`3.10` was chosen as versions `< 3.10` are currently deprecated and support will be removed soon.